### PR TITLE
Extend a list of Target attributes

### DIFF
--- a/classes/image_types_ostree.bbclass
+++ b/classes/image_types_ostree.bbclass
@@ -254,7 +254,10 @@ IMAGE_CMD_garagesign () {
                 bbplain "Running command(${GARAGE_CUSTOMIZE_TARGET}) to customize target"
                 ${GARAGE_CUSTOMIZE_TARGET} \
                     ${GARAGE_SIGN_REPO}/tufrepo/roles/unsigned/targets.json \
-                    ${GARAGE_TARGET_NAME}-${target_version}
+                    ${GARAGE_TARGET_NAME}-${target_version} \
+                    ${MACHINE} \
+                    ${IMAGE_BASENAME} \
+                    ${TARGET_ARCH}
             fi
             garage-sign targets sign --repo tufrepo \
                                      --home-dir ${GARAGE_SIGN_REPO} \


### PR DESCRIPTION
Add `arch` (architecture) and a system image (wic file) file name to
Target attributes ('custom') during 'target customiztion'

Signed-off-by: Mike Sul <mike.sul@foundries.io>